### PR TITLE
fix swap router corner case

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,7 +10,7 @@ const TEST_ACCOUNTS = {
   path: 'm/44\'/60\'/0\'/0',
 };
 
-const PROD_ACCOUNTS = process.env.KEY ? [process.env.KEY] : [];
+const PROD_ACCOUNTS = process.env.KEY ? process.env.KEY.split(',') : [];
 
 const config: HardhatUserConfig = {
   solidity: '0.8.18',

--- a/src/SwapAndStakeEuphratesRouter.sol
+++ b/src/SwapAndStakeEuphratesRouter.sol
@@ -28,7 +28,9 @@ contract SwapAndStakeEuphratesRouter is BaseRouter {
     }
 
     function routeImpl(ERC20 token) internal override {
-        // transfer supplyAmount to maker if possible
+        if (token.balanceOf(address(this)) < _instructions.supplyAmount) {
+            revert("SwapAndStakeEuphratesRouter: not enough token supplied");
+        }
         token.safeTransfer(_instructions.maker, _instructions.supplyAmount);
 
         // stake remain token to euphrates pool

--- a/src/SwapAndStakeEuphratesRouter.sol
+++ b/src/SwapAndStakeEuphratesRouter.sol
@@ -29,7 +29,7 @@ contract SwapAndStakeEuphratesRouter is BaseRouter {
 
     function routeImpl(ERC20 token) internal override {
         // transfer supplyAmount to maker if possible
-        token.safeTransfer(_instructions.maker, Math.min(_instructions.supplyAmount, token.balanceOf(address(this))));
+        token.safeTransfer(_instructions.maker, _instructions.supplyAmount);
 
         // stake remain token to euphrates pool
         if (address(token) == address(IStakingTo(_instructions.euphrates).shareTypes(_instructions.poolId))) {

--- a/test/SwapAndStakeEuphratesRouter.t.sol
+++ b/test/SwapAndStakeEuphratesRouter.t.sol
@@ -167,7 +167,7 @@ contract SwapAndStakeEuphratesRouterTest is Test {
         assertEq(euphrates.shares(0, alice), 0);
 
         vm.prank(bob);
-        vm.expectRevert("TRANSFER_FAILED");
+        vm.expectRevert("SwapAndStakeEuphratesRouter: not enough token supplied");
         router.routeNoFee(token1);
     }
 

--- a/test/SwapAndStakeEuphratesRouter.t.sol
+++ b/test/SwapAndStakeEuphratesRouter.t.sol
@@ -167,15 +167,8 @@ contract SwapAndStakeEuphratesRouterTest is Test {
         assertEq(euphrates.shares(0, alice), 0);
 
         vm.prank(bob);
+        vm.expectRevert("TRANSFER_FAILED");
         router.routeNoFee(token1);
-        assertEq(token1.balanceOf(address(router)), 0);
-        assertEq(token2.balanceOf(address(router)), 0);
-        assertEq(token1.balanceOf(alice), 0);
-        assertEq(token2.balanceOf(alice), 0);
-        assertEq(token1.balanceOf(maker), 6 ether);
-        assertEq(token2.balanceOf(maker), 0);
-        assertEq(token1.balanceOf(address(euphrates)), 0);
-        assertEq(euphrates.shares(0, alice), 0);
     }
 
     function testRescure_withTargetToken() public {


### PR DESCRIPTION
## Change
when there is not enough supply amount provided, we should throw error instead of proceeding. Otherwise malicious user can supply a very small amount and still get full targetAmount of target token.

## Test
updated the test for when there is not enough supply amount
