### PR TITLE
updated rescue to support gas drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/asset-router",
-  "version": "1.0.18",
+  "version": "1.0.19-6",
   "main": "dist/index.js",
   "repository": "git@github.com:AcalaNetwork/asset-router.git",
   "author": "Acala Developers <hello@acala.network>",

--- a/scripts/consts.ts
+++ b/scripts/consts.ts
@@ -53,12 +53,13 @@ export const ADDRESSES = {
   [CHAIN.ACALA_TESTNET]: {
     tokenBridgeAddr: CONTRACTS.TESTNET.acala.token_bridge,
     factoryAddr: '',
-    feeAddr: '0x346a989D3B55a82b3CD8a5ed804E3776Af90925a',              // acala fork
+    feeAddr: '0x5Fc7261E168F6a8c1053F2208c7db4BCbef133b3',              // acala fork
     usdcAddr: '0x7E0CCD4209Ef7039901512fF9f6a01d0de0691e2',
     homaFactoryAddr: '0x2ed9aa0e30D52958E21Db37FfBDC3F0B0fD4b973',      // acala fork
     accountHelperAddr: '0x0252340cC347718f9169d329CEFf8B15A92badf8',    // acala fork
     euphratesFactoryAddr: '0x2AeFc65B6E1660d2bA2796f8698120A2acB95634', // acala fork
     swapAndStakeFactoryAddr: '0x97B15411D65e83F0bDA8D1db628CCC5D003B754d', // acala fork
+    dropAndSwapStakeFactoryAddr: '0xB1DC04892c8346f61aF1A922A856D96e4A51a389', // acala fork
   },
   [CHAIN.KARURA]: {
     tokenBridgeAddr: CONTRACTS.MAINNET.karura.token_bridge,
@@ -77,6 +78,7 @@ export const ADDRESSES = {
     accountHelperAddr: '0x0252340cC347718f9169d329CEFf8B15A92badf8',
     euphratesFactoryAddr: '0x2AeFc65B6E1660d2bA2796f8698120A2acB95634',
     swapAndStakeFactoryAddr: '0x3923E44cf1062FBa513279Ab81e6B8727a6de3D6',
+    dropAndSwapStakeFactoryAddr: '0xB1DC04892c8346f61aF1A922A856D96e4A51a389',
   },
 } as const;
 

--- a/scripts/deploy-drop-swap-stake-factory.ts
+++ b/scripts/deploy-drop-swap-stake-factory.ts
@@ -1,0 +1,21 @@
+import { ethers, run } from 'hardhat';
+
+async function main() {
+  const Factory = await ethers.getContractFactory('DropAndSwapStakeFactory');
+  const factory = await Factory.deploy();
+  await factory.deployed();
+
+  console.log(`swap and stake factory address: ${factory.address}`);
+
+  if (process.env.VERIFY) {
+    await run('verify:verify', {
+      address: factory.address,
+      constructorArguments: [],
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/DropAndSwapStakeFactory.sol
+++ b/src/DropAndSwapStakeFactory.sol
@@ -75,4 +75,15 @@ contract DropAndSwapStakeFactory {
         DropAndSwapStakeRouter router = deployDropAndSwapStakeRouter(fees, inst, dropAmount);
         router.routeNoFee(token);
     }
+
+    function deployDropAndSwapStakeRouterAndRescue(
+        FeeRegistry fees,
+        DropAndSwapStakeInstructions memory inst,
+        ERC20 token,
+        uint256 dropAmount,
+        bool isGasDrop
+    ) public {
+        DropAndSwapStakeRouter router = deployDropAndSwapStakeRouter(fees, inst, dropAmount);
+        router.rescue(token, isGasDrop);
+    }
 }

--- a/src/DropAndSwapStakeRouter.sol
+++ b/src/DropAndSwapStakeRouter.sol
@@ -79,14 +79,25 @@ contract DropAndSwapStakeRouter is BaseRouter {
         _instructions.dropToken.safeTransfer(_instructions.recipient, _instructions.dropToken.balanceOf(address(this)));
     }
 
-    function rescure(ERC20 token) public {
-        // transfer dropFee to feeReceiver if possible
-        token.safeTransfer(_instructions.feeReceiver, Math.min(_instructions.dropFee, token.balanceOf(address(this))));
+    function rescue(ERC20 token, bool isGasDrop) public {
+        if (isGasDrop) {
+            // require transfer full dropFee to feeReceiver
+            if (token.balanceOf(address(this)) < _instructions.dropFee) {
+                revert("DropAndStakeByDEXUtilRouter: cannot afford drop fee");
+            }
+            token.safeTransfer(_instructions.feeReceiver, _instructions.dropFee);
 
-        // transfer it to recipient to avoid it stuck in this contract
+            // transfer all dropToken to recipient
+            _instructions.dropToken.safeTransfer(_instructions.recipient, _instructions.dropToken.balanceOf(address(this)));
+        } else {
+            // transfer all dropToken back to feeReceiver (no gas drop)
+            _instructions.dropToken.safeTransfer(_instructions.feeReceiver, _instructions.dropToken.balanceOf(address(this)));
+        }
+
+        // transfer all remainning token to recipient to avoid it stuck in this contract
         token.safeTransfer(_instructions.recipient, token.balanceOf(address(this)));
 
-        // transfer all dropToken to recipient
-        _instructions.dropToken.safeTransfer(_instructions.recipient, _instructions.dropToken.balanceOf(address(this)));
+        emit RouterDestroyed(address(this));
+        selfdestruct(payable(msg.sender));
     }
 }

--- a/src/DropAndSwapStakeRouter.sol
+++ b/src/DropAndSwapStakeRouter.sol
@@ -98,6 +98,6 @@ contract DropAndSwapStakeRouter is BaseRouter {
         token.safeTransfer(_instructions.recipient, token.balanceOf(address(this)));
 
         emit RouterDestroyed(address(this));
-        selfdestruct(payable(msg.sender));
+        selfdestruct(payable(_instructions.feeReceiver));
     }
 }

--- a/src/HomaRouter.sol
+++ b/src/HomaRouter.sol
@@ -46,7 +46,7 @@ contract HomaRouter is BaseRouter {
      * @dev Withdraws the entire balance of a given ERC20 token to the caller's address, provided that the caller is the designated recipient.
      * @param token The ERC20 token to withdraw from.
      */
-    function rescure(ERC20 token) public {
+    function rescue(ERC20 token) public {
         require(IEVMAccounts(EVM_ACCOUNTS).getAccountId(msg.sender) == _instructions.recipient, "HomaRouter: not recipient");
         token.safeTransfer(msg.sender, token.balanceOf(address(this)));
     }

--- a/src/SwapAndStakeEuphratesRouter.sol
+++ b/src/SwapAndStakeEuphratesRouter.sol
@@ -55,7 +55,7 @@ contract SwapAndStakeEuphratesRouter is BaseRouter {
         );
     }
 
-    function rescure(ERC20 token) public {
+    function rescue(ERC20 token) public {
         // transfer supplyAmount to maker if possible
         token.safeTransfer(_instructions.maker, Math.min(_instructions.supplyAmount, token.balanceOf(address(this))));
 

--- a/test/SwapAndStakeEuphratesRouter.t.sol
+++ b/test/SwapAndStakeEuphratesRouter.t.sol
@@ -171,7 +171,7 @@ contract SwapAndStakeEuphratesRouterTest is Test {
         router.routeNoFee(token1);
     }
 
-    function testRescure_withTargetToken() public {
+    function testRescue_withTargetToken() public {
         SwapAndStakeEuphratesInstructions memory inst =
             SwapAndStakeEuphratesInstructions(alice, 2 ether, maker, token2, 0, address(euphrates));
         SwapAndStakeEuphratesRouter router = new SwapAndStakeEuphratesRouter(fees, inst);
@@ -190,7 +190,7 @@ contract SwapAndStakeEuphratesRouterTest is Test {
         assertEq(euphrates.shares(0, alice), 0);
 
         vm.prank(bob);
-        router.rescure(token1);
+        router.rescue(token1);
         assertEq(token1.balanceOf(address(router)), 0);
         assertEq(token2.balanceOf(address(router)), 0);
         assertEq(token1.balanceOf(alice), 4 ether);

--- a/test/homa-router.test.ts
+++ b/test/homa-router.test.ts
@@ -231,9 +231,9 @@ describe('Homa Router', () => {
 
       const router = HomaRouter__factory.connect(routerAddr, relayer);
 
-      await expect(router.rescure(token.address)).to.be.revertedWith('HomaRouter: not recipient');    // relayer is not the recipient
+      await expect(router.rescue(token.address)).to.be.revertedWith('HomaRouter: not recipient');    // relayer is not the recipient
 
-      await (await router.connect(user).rescure(token.address)).wait();   // user is the recipient
+      await (await router.connect(user).rescue(token.address)).wait();   // user is the recipient
     } else {
       const deployAndRoute = await factory.deployHomaRouterAndRouteNoFee(
         fee.address,


### PR DESCRIPTION
## Changed
- updated rescue method to take a `isGasDrop` param, which is used by relayer. When swap or add liquidity failed (usually due to minShared not met), we can use `deployDropAndSwapStakeRouterAndRescue` method to rescue token + gas drop, so user can still stake manually
- added deploy script

## Test
e2e tested with [relayer](https://github.com/AcalaNetwork/wormhole-relayer/pull/71) and worked as expected 