### PR TITLE
not destruct router in bootstrap step

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -31,7 +31,7 @@ const config: HardhatUserConfig = {
       chainId: 597,
     },
     acalaFork: {
-      url: 'https://crosschain-dev.polkawallet.io/forkAcala/',
+      url: 'https://crosschain-dev.polkawallet.io/chopsticksAcalaRpc',
       accounts: MY_ACCOUNTS,
       chainId: 787,
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/asset-router",
-  "version": "1.0.19-6",
+  "version": "1.0.19-10",
   "main": "dist/index.js",
   "repository": "git@github.com:AcalaNetwork/asset-router.git",
   "author": "Acala Developers <hello@acala.network>",

--- a/scripts/consts.ts
+++ b/scripts/consts.ts
@@ -59,7 +59,8 @@ export const ADDRESSES = {
     accountHelperAddr: '0x0252340cC347718f9169d329CEFf8B15A92badf8',    // acala fork
     euphratesFactoryAddr: '0x2AeFc65B6E1660d2bA2796f8698120A2acB95634', // acala fork
     swapAndStakeFactoryAddr: '0x97B15411D65e83F0bDA8D1db628CCC5D003B754d', // acala fork
-    dropAndSwapStakeFactoryAddr: '0xB1DC04892c8346f61aF1A922A856D96e4A51a389', // acala fork
+    dropAndSwapStakeFactoryAddr: '0xf5227838253d325f99346c82b924C69347a00d00', // acala fork
+    dropAndBootstrapStakeFactoryAddr: '0x1C7426D333b18Dbc050fc306E48DaA9a4A926b9b', // acala fork
   },
   [CHAIN.KARURA]: {
     tokenBridgeAddr: CONTRACTS.MAINNET.karura.token_bridge,
@@ -78,7 +79,8 @@ export const ADDRESSES = {
     accountHelperAddr: '0x0252340cC347718f9169d329CEFf8B15A92badf8',
     euphratesFactoryAddr: '0x2AeFc65B6E1660d2bA2796f8698120A2acB95634',
     swapAndStakeFactoryAddr: '0x3923E44cf1062FBa513279Ab81e6B8727a6de3D6',
-    dropAndSwapStakeFactoryAddr: '0xB1DC04892c8346f61aF1A922A856D96e4A51a389',
+    dropAndSwapStakeFactoryAddr: '0xf5227838253d325f99346c82b924C69347a00d00',    // acala fork
+    dropAndBootstrapStakeFactoryAddr: '0x1C7426D333b18Dbc050fc306E48DaA9a4A926b9b', // acala fork
   },
 } as const;
 

--- a/scripts/deploy-drop-and-bootstrap-stake-factory.ts
+++ b/scripts/deploy-drop-and-bootstrap-stake-factory.ts
@@ -1,0 +1,21 @@
+import { ethers, run } from 'hardhat';
+
+async function main() {
+  const Factory = await ethers.getContractFactory('DropAndBootstrapStakeFactory');
+  const factory = await Factory.deploy();
+  await factory.deployed();
+
+  console.log(`drop and bootstrap factory address: ${factory.address}`);
+
+  if (process.env.VERIFY) {
+    await run('verify:verify', {
+      address: factory.address,
+      constructorArguments: [],
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/DropAndBootstrapStakeFactory.sol
+++ b/src/DropAndBootstrapStakeFactory.sol
@@ -63,7 +63,7 @@ contract DropAndBootstrapStakeFactory {
         uint256 dropAmount
     ) public {
         DropAndBootstrapStakeRouter router = deployDropAndBootstrapStakeRouter(fees, inst, dropAmount);
-        router.route(token, msg.sender);
+        router.route(token, msg.sender, false);
     }
 
     function deployDropAndBootstrapStakeRouterAndRouteNoFee(

--- a/src/DropAndBootstrapStakeRouter.sol
+++ b/src/DropAndBootstrapStakeRouter.sol
@@ -73,6 +73,11 @@ contract DropAndBootstrapStakeRouter is BaseRouter {
         _instructions.dropToken.safeTransfer(_instructions.recipient, _instructions.dropToken.balanceOf(address(this)));
     }
 
+    function _destroy() private {
+        emit RouterDestroyed(address(this));
+        selfdestruct(payable(_instructions.feeReceiver));
+    }
+
     function claimShareAndStakeTo(ERC20 token) public {
         // ensure bootstrap has been existed and ended
         address lpToken = IDEX(_instructions.dex).getLiquidityTokenAddress(
@@ -111,6 +116,8 @@ contract DropAndBootstrapStakeRouter is BaseRouter {
                 IStakingTo(_instructions.euphrates).stakeTo(_instructions.poolId, stakeAmount, _instructions.recipient);
             require(stakeResult, "DropAndBootstrapStakeRouter: stakeTo failed");
         }
+
+        _destroy();
     }
 
     function refundProvision(ERC20 token) public {
@@ -142,6 +149,8 @@ contract DropAndBootstrapStakeRouter is BaseRouter {
         _instructions.otherContributionToken.safeTransfer(
             _instructions.recipient, _instructions.otherContributionToken.balanceOf(address(this))
         );
+
+        _destroy();
     }
 
     function rescue(ERC20 token, bool isGasDrop) public {
@@ -183,7 +192,6 @@ contract DropAndBootstrapStakeRouter is BaseRouter {
             ERC20(lpToken).safeTransfer(_instructions.recipient, ERC20(lpToken).balanceOf(address(this)));
         }
 
-        emit RouterDestroyed(address(this));
-        selfdestruct(payable(_instructions.feeReceiver));
+        _destroy();
     }
 }


### PR DESCRIPTION
## Change
when doing bootstrap, it [increases consumer](https://github.com/AcalaNetwork/Acala/blob/master/modules/dex/src/lib.rs#L960), so we can't destroy the router contract (is it a expected behavior for evm contract?).

If this is expected, we can workaround by keeping the contract for bootstrapping, and destroy it only in the next step (claimShareAndStakeTo or refundProvision).

## Test
tested with testnet relayer, and bootstrap worked. 