### PR TITLE
fix bootstrap rescue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/asset-router",
-  "version": "1.0.19-13",
+  "version": "1.0.19-17",
   "main": "dist/index.js",
   "repository": "git@github.com:AcalaNetwork/asset-router.git",
   "author": "Acala Developers <hello@acala.network>",

--- a/scripts/consts.ts
+++ b/scripts/consts.ts
@@ -59,8 +59,8 @@ export const ADDRESSES = {
     accountHelperAddr: '0x0252340cC347718f9169d329CEFf8B15A92badf8',    // acala fork
     euphratesFactoryAddr: '0x2AeFc65B6E1660d2bA2796f8698120A2acB95634', // acala fork
     swapAndStakeFactoryAddr: '0x97B15411D65e83F0bDA8D1db628CCC5D003B754d', // acala fork
-    dropAndSwapStakeFactoryAddr: '0xf5227838253d325f99346c82b924C69347a00d00', // acala fork
-    dropAndBootstrapStakeFactoryAddr: '0x05598F8A9a74f6BDc31F9Da93B051114c0a41923', // acala fork
+    dropAndSwapStakeFactoryAddr: '0x0F2A7a306D26697876689df9bdc5274982563505', // acala fork
+    dropAndBootstrapStakeFactoryAddr: '0x1C7426D333b18Dbc050fc306E48DaA9a4A926b9b', // acala fork
   },
   [CHAIN.KARURA]: {
     tokenBridgeAddr: CONTRACTS.MAINNET.karura.token_bridge,
@@ -79,8 +79,8 @@ export const ADDRESSES = {
     accountHelperAddr: '0x0252340cC347718f9169d329CEFf8B15A92badf8',
     euphratesFactoryAddr: '0x2AeFc65B6E1660d2bA2796f8698120A2acB95634',
     swapAndStakeFactoryAddr: '0x3923E44cf1062FBa513279Ab81e6B8727a6de3D6',
-    dropAndSwapStakeFactoryAddr: '0xf5227838253d325f99346c82b924C69347a00d00',    // acala fork
-    dropAndBootstrapStakeFactoryAddr: '0x05598F8A9a74f6BDc31F9Da93B051114c0a41923', // acala fork
+    dropAndSwapStakeFactoryAddr: '0x0F2A7a306D26697876689df9bdc5274982563505',    // acala fork
+    dropAndBootstrapStakeFactoryAddr: '0x1C7426D333b18Dbc050fc306E48DaA9a4A926b9b', // acala fork
   },
 } as const;
 

--- a/src/DropAndBootstrapStakeFactory.sol
+++ b/src/DropAndBootstrapStakeFactory.sol
@@ -23,8 +23,6 @@ contract DropAndBootstrapStakeFactory {
 
         // no need to use salt as we want to keep the router address the same for the same fees &instructions
         bytes32 salt;
-        DropAndBootstrapStakeRouter router;
-
         bytes memory bytecode = abi.encodePacked(type(DropAndBootstrapStakeRouter).creationCode, abi.encode(fees, inst));
         address routerAddr = Create2.computeAddress(salt, keccak256(bytecode));
 
@@ -63,10 +61,9 @@ contract DropAndBootstrapStakeFactory {
         FeeRegistry fees,
         DropAndBootstrapStakeInstructions memory inst,
         ERC20 token,
-        uint256 dropAmount,
-        bool isGasDrop
+        uint256 dropAmount
     ) public {
         DropAndBootstrapStakeRouter router = deployDropAndBootstrapStakeRouter(fees, inst, dropAmount);
-        router.rescue(token, isGasDrop);
+        router.rescue(token);
     }
 }

--- a/src/DropAndBootstrapStakeRouter.sol
+++ b/src/DropAndBootstrapStakeRouter.sol
@@ -162,34 +162,7 @@ contract DropAndBootstrapStakeRouter is BaseRouter {
         _destroy();
     }
 
-    function rescue(ERC20 token, bool isGasDrop) public {
-        (uint256 contributionA, uint256 contributionB) = IBootstrap(_instructions.dex).getProvisionPoolOf(
-            address(this), address(token), address(_instructions.otherContributionToken)
-        );
-        require(
-            contributionA == 0 && contributionB == 0,
-            "DropAndBootstrapStakeRouter: exist provision, must claim share or refund provision"
-        );
-
-        if (!_dropped) {
-            if (isGasDrop) {
-                // require transfer full dropFee to feeReceiver
-                if (token.balanceOf(address(this)) < _instructions.dropFee) {
-                    revert("DropAndBootstrapStakeRouter: cannot afford drop fee");
-                }
-                token.safeTransfer(_instructions.feeReceiver, _instructions.dropFee);
-                // transfer all dropToken to recipient
-                _instructions.dropToken.safeTransfer(
-                    _instructions.recipient, _instructions.dropToken.balanceOf(address(this))
-                );
-            } else {
-                // transfer all dropToken back to feeReceiver (no gas drop)
-                _instructions.dropToken.safeTransfer(
-                    _instructions.feeReceiver, _instructions.dropToken.balanceOf(address(this))
-                );
-            }
-        }
-
+    function rescue(ERC20 token) public {
         // transfer all remainning token to recipient to avoid it stuck in this contract
         token.safeTransfer(_instructions.recipient, token.balanceOf(address(this)));
         _instructions.otherContributionToken.safeTransfer(
@@ -202,7 +175,5 @@ contract DropAndBootstrapStakeRouter is BaseRouter {
         if (lpToken != address(0)) {
             ERC20(lpToken).safeTransfer(_instructions.recipient, ERC20(lpToken).balanceOf(address(this)));
         }
-
-        _destroy();
     }
 }


### PR DESCRIPTION
## Change
in our current implementation, if the router address has already participated in the bootstrapping, rescue will fail:
- it won't pass the check of `contributionA == 0 && contributionB == 0`
- it cannot selfdestruct

so let's just rollback to the minimum version: transfer all tokens back to the recipient, and keep the router contract intact.

## Test
WIP